### PR TITLE
Add deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["src"]
+ :aliases
+ {:dev {:extra-paths ["test"]}}}


### PR DESCRIPTION
Since the clojars version is outdated, the deps.edn file will allow non lein users to add the compound dependency simply like this:
```
compound {:git/url "https://github.com/riverford/compound.git"
          :sha "..."}
```
